### PR TITLE
Feature/Add support for domain-model 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
   "require": {
     "php": "^8.2",
     "ext-json": "*",
-    "complex-heart/domain-model": "^5.0.0"
+    "complex-heart/domain-model": "^5.0.0 || ^6.0.0"
   },
   "require-dev": {
     "mockery/mockery": "^1.6.0",


### PR DESCRIPTION
Widens the `complex-heart/domain-model` range to accept 6.x, which dropped Illuminate 11.

No API change here, so this goes out as a minor. Verified against both 5.x and 6.x: 37 tests, PHPStan and Pint green.